### PR TITLE
Coerce all nested columns to character before unnesting

### DIFF
--- a/R/fetch_data_dictionary.R
+++ b/R/fetch_data_dictionary.R
@@ -34,8 +34,13 @@ fetch_data_dictionary <- function(survey_id, token = "token", secret_key = "secr
       page = 1
     )
 
-  temp_df <- jsonlite::fromJSON(survey$url, flatten = TRUE)
-  temp_df <- temp_df$data
+  temp_df <- jsonlite::fromJSON(survey$url, flatten = TRUE)$data
+  
+  # Coerce all columns in the nested data frames to character vectors
+  temp_df$options <- lapply(temp_df$options, function(x) {
+    if (is.null(x)) return(NULL)
+    as.data.frame(lapply(x, as.character), stringsAsFactors = FALSE)
+  })
 
   temp_df |>
     dplyr::select(id,


### PR DESCRIPTION
If there are numeric values in the nested data frames, it fails to combine them in the un-nesting step:

```r
>   temp_df |>
+     dplyr::select(id,
+                   "label" = title.English,
+                   options) |>
+     tidyr::unnest(options,
+                   names_sep = "_",
+                   keep_empty = TRUE)
Error in `list_unchop()`:
! Can't combine `x[[1]]$title.English` <character> and `x[[17]]$title.English` <integer>.
Run `rlang::last_trace()` to see where the error occurred.
```

Ugly `lapply()`, but I don't know of another way to makes sure all the nested variables are character type.